### PR TITLE
fix: enforce design tokens across frontend (css) (#144)

### DIFF
--- a/frontend/src/app/alert/page.tsx
+++ b/frontend/src/app/alert/page.tsx
@@ -58,7 +58,7 @@ function EmptyState() {
         --color-mist would be near-invisible on white; --color-body gives enough contrast.
       */}
       <p
-        className="text-[15px] font-semibold"
+        className="text-base font-semibold"
         style={{ color: "var(--color-body)" }}
       >
         No alerts
@@ -76,15 +76,15 @@ function ErrorState({
 }) {
   return (
     <div className="flex flex-col items-center justify-center py-20 text-center gap-3">
-      <p className="text-[15px] font-semibold text-red-400">
+      <p className="text-base font-semibold text-threat">
         Failed to load alerts
       </p>
-      <p className="text-xs text-white/40 max-w-xs">{message}</p>
+      <p className="text-xs text-mist max-w-xs">{message}</p>
       <Button
         size="sm"
         variant="outline"
         onClick={onRetry}
-        className="border-[#2C3E6B] text-[#D0D7E8] hover:bg-[#2C3E6B] hover:text-white text-xs"
+        className="border-steel text-mist hover:bg-steel hover:text-white text-xs"
       >
         Try again
       </Button>
@@ -102,14 +102,14 @@ function ActionErrorBanner({
   return (
     <div
       role="alert"
-      className="mb-4 flex items-center gap-2 rounded-lg border border-[#DC2626]/30 bg-[#DC2626]/10 px-4 py-3 text-sm text-[#DC2626]"
+      className="mb-4 flex items-center gap-2 rounded-lg border border-threat/30 bg-threat/10 px-4 py-3 text-sm text-threat"
     >
       <span className="flex-1">{message}</span>
       <button
         type="button"
         onClick={onDismiss}
         aria-label="Dismiss error"
-        className="ml-2 text-[#DC2626]/60 hover:text-[#DC2626] transition-colors"
+        className="ml-2 text-threat/60 hover:text-threat transition-colors"
       >
         ✕
       </button>
@@ -381,9 +381,9 @@ export default function AlertsPage({
   if (identityLoading) {
     return (
       <TooltipProvider>
-        <div className="w-full min-h-full flex items-center justify-center px-8 py-10 bg-[#1D2A5E] text-white/70">
+        <div className="w-full min-h-full flex items-center justify-center px-8 py-10 bg-navy text-mist">
           <div className="flex items-center gap-2">
-            <RefreshCw className="h-4 w-4 animate-spin text-[#5B8DEF]" />
+            <RefreshCw className="h-4 w-4 animate-spin text-sky" />
             Resolving neighbourhood context...
           </div>
         </div>
@@ -394,10 +394,10 @@ export default function AlertsPage({
   if (!neighbourhoodId) {
     return (
       <TooltipProvider>
-        <div className="w-full min-h-full flex items-center justify-center px-8 py-10 bg-[#1D2A5E] text-center">
-          <Card className="max-w-md bg-[#2C3E6B]/40 border-[#2C3E6B] rounded-2xl p-6 text-white">
+        <div className="w-full min-h-full flex items-center justify-center px-8 py-10 bg-navy text-center">
+          <Card className="max-w-md bg-steel/40 border-steel rounded-xl p-6 text-white">
             <p className="text-lg font-semibold">Alerts need a neighbourhood</p>
-            <p className="mt-2 text-sm text-white/60">
+            <p className="mt-2 text-sm text-mist">
               {identityError ||
                 "Open this page with a neighbourhood ID, or sign in to a user that already belongs to one."}
             </p>
@@ -409,11 +409,11 @@ export default function AlertsPage({
 
   return (
     <TooltipProvider>
-      <div className="w-full flex flex-col items-center px-8 py-10 bg-[#1D2A5E] min-h-full font-sans">
+      <div className="w-full flex flex-col items-center px-8 py-10 bg-navy min-h-full font-sans">
         <div className="w-full max-w-2xl">
           <header className="mb-6 text-center">
             <div className="flex items-center justify-center gap-2">
-              <h1 className="text-[32px] font-bold leading-10 text-white">
+              <h1 className="text-[2rem] font-bold leading-[2.5rem] text-white">
                 Alerts
               </h1>
               <span
@@ -425,9 +425,9 @@ export default function AlertsPage({
                 aria-label={wsConnected ? "Live" : "Offline"}
               >
                 {wsConnected ? (
-                  <Wifi className="h-4 w-4 text-[#16A34A] mt-1" />
+                  <Wifi className="h-4 w-4 text-safe mt-1" />
                 ) : (
-                  <WifiOff className="h-4 w-4 text-white/30 mt-1" />
+                  <WifiOff className="h-4 w-4 text-mist/50 mt-1" />
                 )}
               </span>
             </div>
@@ -480,9 +480,9 @@ export default function AlertsPage({
             />
           )}
 
-          <Card className="bg-[#2C3E6B]/40 border-[#2C3E6B] rounded-2xl">
+          <Card className="bg-steel/40 border-steel rounded-xl">
             {/* Toolbar */}
-            <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-[#2C3E6B] rounded-t-2xl">
+            <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-steel rounded-t-xl">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -512,7 +512,7 @@ export default function AlertsPage({
                         White on --color-blue ≥ 4.5:1 per spec contrast table.
                       */
                       <span
-                        className="ml-1.5 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold"
+                        className="ml-1.5 flex h-4 w-4 items-center justify-center rounded-full text-xs font-bold"
                         style={{
                           backgroundColor: "var(--color-blue)",
                           color: "var(--color-white)",
@@ -539,7 +539,7 @@ export default function AlertsPage({
                 >
                   {/* Section label: caption-weight, --color-body for subdued tone */}
                   <DropdownMenuLabel
-                    className="text-[10px] uppercase tracking-wider"
+                    className="text-xs uppercase tracking-wider"
                     style={{ color: "var(--color-body)" }}
                   >
                     Severity
@@ -571,7 +571,7 @@ export default function AlertsPage({
                   />
 
                   <DropdownMenuLabel
-                    className="text-[10px] uppercase tracking-wider"
+                    className="text-xs uppercase tracking-wider"
                     style={{ color: "var(--color-body)" }}
                   >
                     Status
@@ -634,7 +634,7 @@ export default function AlertsPage({
                 size="sm"
                 onClick={triggerRefresh}
                 disabled={loading}
-                className="text-[#5B8DEF] hover:text-white hover:bg-[#2C3E6B] transition-colors text-xs"
+                className="text-sky hover:text-white hover:bg-steel transition-colors text-xs"
                 aria-label="Refresh alerts"
               >
                 <RefreshCw
@@ -648,11 +648,11 @@ export default function AlertsPage({
             <section
               aria-label="Alert list"
               aria-live="polite"
-              className="p-4 rounded-b-2xl"
+              className="p-4 rounded-b-xl"
             >
               {loading && alerts.length === 0 ? (
                 <div className="flex items-center justify-center py-20">
-                  <RefreshCw className="h-5 w-5 animate-spin text-[#5B8DEF]" />
+                  <RefreshCw className="h-5 w-5 animate-spin text-sky" />
                 </div>
               ) : error ? (
                 <ErrorState

--- a/frontend/src/app/auth/forgotpassword/layout.tsx
+++ b/frontend/src/app/auth/forgotpassword/layout.tsx
@@ -6,7 +6,7 @@ export default function ForgotPasswordLayout({ children }: { children: ReactNode
       className="min-h-screen flex items-center justify-center px-4"
       style={{
         background:
-          "radial-gradient(circle at top, rgba(91, 141, 239, 0.16), transparent 32%), linear-gradient(180deg, var(--color-fog) 0%, #ffffff 100%)",
+          "radial-gradient(circle at top, color-mix(in srgb, var(--color-sky) 16%, transparent), transparent 32%), linear-gradient(180deg, var(--color-fog) 0%, var(--color-white) 100%)",
       }}
     >
       {children}

--- a/frontend/src/app/auth/login/layout.tsx
+++ b/frontend/src/app/auth/login/layout.tsx
@@ -6,7 +6,7 @@ export default function LoginLayout({ children }: { children: ReactNode }) {
       className="min-h-screen flex items-center justify-center px-4"
       style={{
         background:
-          "radial-gradient(circle at top, rgba(91, 141, 239, 0.16), transparent 32%), linear-gradient(180deg, var(--color-fog) 0%, #ffffff 100%)",
+          "radial-gradient(circle at top, color-mix(in srgb, var(--color-sky) 16%, transparent), transparent 32%), linear-gradient(180deg, var(--color-fog) 0%, var(--color-white) 100%)",
       }}
     >
       {children}

--- a/frontend/src/app/auth/signup/layout.tsx
+++ b/frontend/src/app/auth/signup/layout.tsx
@@ -6,7 +6,7 @@ export default function SignUpLayout({ children }: { children: ReactNode }) {
       className="min-h-screen flex items-center justify-center px-4"
       style={{
         background:
-          "radial-gradient(circle at top, rgba(91, 141, 239, 0.16), transparent 32%), linear-gradient(180deg, var(--color-fog) 0%, #ffffff 100%)",
+          "radial-gradient(circle at top, color-mix(in srgb, var(--color-sky) 16%, transparent), transparent 32%), linear-gradient(180deg, var(--color-fog) 0%, var(--color-white) 100%)",
       }}
     >
       {children}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -56,7 +56,7 @@ export default function Dashboard() {
                 <h1 className="text-2xl font-bold">Property Name</h1>
                 <Button
                     onClick={() => setShowCard(true)}
-                    className="bg-blue-500 hover:bg-blue-600 text-white rounded-full"
+                    className="bg-blue hover:bg-sky text-white rounded-full"
                 >
                     <Plus size={16} className="mr-1" />
                     Add Camera

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -42,6 +42,18 @@
   --radius-lg: 12px;
   --radius-xl: 16px;
   --radius-full: 9999px;
+  --color-navy: #1D2A5E;
+  --color-blue: #3B5EDE;
+  --color-sky: #5B8DEF;
+  --color-steel: #2C3E6B;
+  --color-fog: #F4F6FA;
+  --color-mist: #D0D7E8;
+  --color-ink: #1A1A2E;
+  --color-body: #2E3A5C;
+  --color-threat: #DC2626;
+  --color-caution: #D97706;
+  --color-safe: #16A34A;
+  --color-info: #0284C7;
 }
 
 :root {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -37,49 +37,46 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 9999px;
 }
 
 :root {
-  /* Tailwind defaults */
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: #1D2A5E;
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* shadcn mapped to WatchDog Design System */
+  --background: #FFFFFF;           /* White */
+  --foreground: #1A1A2E;           /* Ink */
+  --card: #FFFFFF;                 /* White */
+  --card-foreground: #1A1A2E;      /* Ink */
+  --popover: #FFFFFF;              /* White */
+  --popover-foreground: #1A1A2E;   /* Ink */
+  --primary: #3B5EDE;              /* Alert Blue - primary interactive */
+  --primary-foreground: #FFFFFF;   /* White on blue */
+  --secondary: #F4F6FA;            /* Fog */
+  --secondary-foreground: #2C3E6B; /* Steel */
+  --muted: #F4F6FA;                /* Fog */
+  --muted-foreground: #2E3A5C;     /* Body */
+  --accent: #F4F6FA;               /* Fog */
+  --accent-foreground: #1D2A5E;    /* Navy */
+  --destructive: #DC2626;          /* Threat Red */
+  --border: #D0D7E8;               /* Mist */
+  --input: #F4F6FA;                /* Fog - input backgrounds */
+  --ring: #3B5EDE;                 /* Alert Blue - focus rings */
+  --chart-1: #3B5EDE;              /* Alert Blue */
+  --chart-2: #5B8DEF;              /* Sky Blue */
+  --chart-3: #1D2A5E;              /* Navy */
+  --chart-4: #2C3E6B;              /* Steel */
+  --chart-5: #D0D7E8;              /* Mist */
+  --sidebar: #1D2A5E;              /* Navy */
+  --sidebar-foreground: #FFFFFF;   /* White on navy */
+  --sidebar-primary: #3B5EDE;      /* Alert Blue */
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2C3E6B;       /* Steel - hover on navy */
+  --sidebar-accent-foreground: #FFFFFF;
+  --sidebar-border: #2C3E6B;       /* Steel */
+  --sidebar-ring: #3B5EDE;         /* Alert Blue */
 
   /* WatchDog Design System Tokens */
   /* Colour - Brand */
@@ -102,8 +99,18 @@
   --color-info: #0284C7;
 
   /* Typography */
-  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-sans: 'Inter', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', Consolas, monospace;
+  --text-display: 3rem/3.5rem var(--font-sans);
+  --text-h1: 2rem/2.5rem var(--font-sans);
+  --text-h2: 1.5rem/2rem var(--font-sans);
+  --text-h3: 1.25rem/1.75rem var(--font-sans);
+  --text-body-lg: 1.125rem/1.75rem var(--font-sans);
+  --text-body: 1rem/1.5rem var(--font-sans);
+  --text-sm: 0.875rem/1.25rem var(--font-sans);
+  --text-label: 0.875rem/1.25rem var(--font-sans);
+  --text-caption: 0.75rem/1rem var(--font-sans);
+  --text-code: 0.875rem/1.25rem var(--font-mono);
 
   /* Spacing */
   --space-1: 4px;
@@ -124,9 +131,11 @@
   --radius-full: 9999px;
 
   /* Motion */
+  --motion-instant: 0ms;
   --motion-fast: 100ms ease-out;
   --motion-normal: 200ms ease-in-out;
   --motion-slow: 350ms ease-in-out;
+  --motion-alert-pulse: 1200ms ease-in-out infinite;
 
   /* Shadows */
   --shadow-sm: 0 1px 3px rgba(29, 42, 94, 0.08);
@@ -134,71 +143,71 @@
   --shadow-lg: 0 8px 24px rgba(29, 42, 94, 0.16);
   --shadow-alert: 0 0 0 3px rgba(220, 38, 38, 0.30);
 
-    --toast-bg: #ffffff;
-    --toast-text: #0f172a;
-    --toast-border: #e2e8f0;
+  --toast-bg: #FFFFFF;           /* White */
+  --toast-text: #1A1A2E;         /* Ink */
+  --toast-border: #D0D7E8;       /* Mist */
 
-    --toast-success: #065f46; /* dark green */
-    --toast-success-text: #ecfdf5;
+  --toast-success: #16A34A;      /* Safe Green */
+  --toast-success-text: #FFFFFF;
 
-    --toast-warning: #d6b780; /* amber */
-    --toast-warning-text: #111827;
+  --toast-warning: #D97706;      /* Caution Amber */
+  --toast-warning-text: #FFFFFF;
 
-    --toast-error: #b91c1c;   /* red */
-    --toast-error-text: #fef2f2;
+  --toast-error: #DC2626;        /* Threat Red */
+  --toast-error-text: #FFFFFF;
 
-    --toast-info: #0ea5e9;    /* sky */
-    --toast-info-text: #f0f9ff;
+  --toast-info: #0284C7;         /* Info Blue */
+  --toast-info-text: #FFFFFF;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: #1D2A5E;
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #1A1A2E;                   /* Ink */
+  --foreground: #F4F6FA;                   /* Fog */
+  --card: #2C3E6B;                         /* Steel */
+  --card-foreground: #F4F6FA;              /* Fog */
+  --popover: #2C3E6B;                      /* Steel */
+  --popover-foreground: #F4F6FA;           /* Fog */
+  --primary: #5B8DEF;                      /* Sky Blue (lighter for dark bg) */
+  --primary-foreground: #FFFFFF;
+  --secondary: #1D2A5E;                    /* Navy */
+  --secondary-foreground: #F4F6FA;         /* Fog */
+  --muted: #1D2A5E;                        /* Navy */
+  --muted-foreground: #D0D7E8;             /* Mist */
+  --accent: #1D2A5E;                       /* Navy */
+  --accent-foreground: #F4F6FA;            /* Fog */
+  --destructive: #DC2626;                  /* Threat Red */
+  --border: rgba(208, 215, 232, 0.15);     /* Mist at 15% */
+  --input: rgba(208, 215, 232, 0.15);      /* Mist at 15% */
+  --ring: #5B8DEF;                         /* Sky Blue */
+  --chart-1: #5B8DEF;                      /* Sky Blue */
+  --chart-2: #3B5EDE;                      /* Alert Blue */
+  --chart-3: #D0D7E8;                      /* Mist */
+  --chart-4: #F4F6FA;                      /* Fog */
+  --chart-5: #2C3E6B;                      /* Steel */
+  --sidebar: #1A1A2E;                      /* Ink */
+  --sidebar-foreground: #FFFFFF;
+  --sidebar-primary: #5B8DEF;              /* Sky Blue */
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #2C3E6B;              /* Steel */
+  --sidebar-accent-foreground: #FFFFFF;
+  --sidebar-border: rgba(208, 215, 232, 0.15);
+  --sidebar-ring: #5B8DEF;
 
-  --toast-bg: #0b0f14;
-  --toast-text: #f8fafc;
-  --toast-border: #1f2937;
+  --toast-bg: #1A1A2E;            /* Ink */
+  --toast-text: #F4F6FA;          /* Fog */
+  --toast-border: #2C3E6B;        /* Steel */
 
-  --toast-success: #10b981;
-  --toast-success-text: #052e1b;
+  --toast-success: #16A34A;       /* Safe Green */
+  --toast-success-text: #FFFFFF;
 
-  --toast-warning: #fbbf24;
-  --toast-warning-text: #0b0f14;
+  --toast-warning: #D97706;       /* Caution Amber */
+  --toast-warning-text: #FFFFFF;
 
-  --toast-error: #f87171;
-  --toast-error-text: #0b0f14;
+  --toast-error: #DC2626;         /* Threat Red */
+  --toast-error-text: #FFFFFF;
 
-  --toast-info: #38bdf8;
-  --toast-info-text: #0b0f14;
+  --toast-info: #5B8DEF;          /* Sky Blue (lighter for dark bg) */
+  --toast-info-text: #FFFFFF;
 }
 
 @layer base {
@@ -206,7 +215,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground font-mono;
+    @apply bg-background text-foreground font-sans;
   }
   html {
     @apply font-sans;

--- a/frontend/src/app/joinNeighbourhood/page.tsx
+++ b/frontend/src/app/joinNeighbourhood/page.tsx
@@ -41,7 +41,7 @@ function StatusRow({
       className={`flex items-center gap-2 text-sm ${muted ? "opacity-40" : ""}`}
     >
       <Icon className={`h-4 w-4 shrink-0 ${color}`} />
-      <span className={done ? "text-white" : "text-[#D0D7E8]/70"}>{label}</span>
+      <span className={done ? "text-white" : "text-mist/70"}>{label}</span>
     </div>
   );
 }
@@ -50,26 +50,26 @@ function PendingState({ request }: { request: JoinRequest }) {
   return (
     <div className="space-y-5 py-1" role="status" aria-live="polite">
       <div className="text-center space-y-2">
-        <div className="mx-auto h-12 w-12 rounded-full bg-[#3B5EDE]/15 border border-[#3B5EDE]/30 flex items-center justify-center">
-          <Clock className="h-6 w-6 text-[#5B8DEF]" />
+        <div className="mx-auto h-12 w-12 rounded-full bg-blue/15 border border-blue/30 flex items-center justify-center">
+          <Clock className="h-6 w-6 text-sky" />
         </div>
-        <p className="text-[15px] font-semibold text-white">
+        <p className="text-base font-semibold text-white">
           Request sent — awaiting approval
         </p>
-        <p className="text-sm text-[#D0D7E8]/60 max-w-[320px] mx-auto">
+        <p className="text-sm text-mist/60 max-w-[320px] mx-auto">
           Your admin has been notified. You&apos;ll receive a notification once
           your request is approved or denied. You cannot access neighbourhood
           data until approved.
         </p>
       </div>
 
-      <Separator className="bg-[#2C3E6B]" />
+      <Separator className="bg-steel" />
 
-      <div className="bg-[#1D2A5E] rounded-lg p-3 border border-[#2C3E6B]">
-        <p className="text-[10px] text-[#D0D7E8]/50 uppercase tracking-wider mb-1">
+      <div className="bg-navy rounded-lg p-3 border border-steel">
+        <p className="text-xs text-mist/50 uppercase tracking-wider mb-1">
           Request ID
         </p>
-        <p className="text-xs font-mono text-[#5B8DEF] break-all">
+        <p className="text-xs font-mono text-sky break-all">
           {request.id}
         </p>
       </div>
@@ -77,18 +77,18 @@ function PendingState({ request }: { request: JoinRequest }) {
       <div className="space-y-2">
         <StatusRow
           icon={CheckCircle2}
-          color="text-[#16A34A]"
+          color="text-safe"
           label="Request submitted"
           done
         />
         <StatusRow
           icon={Clock}
-          color="text-[#D97706]"
+          color="text-caution"
           label="Admin review in progress"
         />
         <StatusRow
           icon={ShieldCheck}
-          color="text-[#D0D7E8]/30"
+          color="text-mist/30"
           label="Access granted"
           muted
         />
@@ -118,7 +118,7 @@ function JoinForm({
       <div className="space-y-2">
         <Label
           htmlFor="join-code"
-          className="text-sm font-medium text-[#D0D7E8]"
+          className="text-sm font-medium text-mist"
         >
           Join code
         </Label>
@@ -136,11 +136,11 @@ function JoinForm({
           aria-invalid={!!error}
           disabled={loading}
           className={[
-            "bg-[#1D2A5E] border-[#2C3E6B] text-white placeholder:text-[#D0D7E8]/30",
+            "bg-navy border-steel text-white placeholder:text-mist/30",
             "font-mono tracking-widest text-sm",
-            "focus-visible:ring-2 focus-visible:ring-[#3B5EDE] focus-visible:ring-offset-0",
+            "focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-offset-0",
             "transition-colors duration-100",
-            error ? "border-[#DC2626]/60 focus-visible:ring-[#DC2626]" : "",
+            error ? "border-threat/60 focus-visible:ring-threat" : "",
           ]
             .filter(Boolean)
             .join(" ")}
@@ -149,13 +149,13 @@ function JoinForm({
           <p
             id="join-code-error"
             role="alert"
-            className="flex items-center gap-1.5 text-xs text-[#DC2626]"
+            className="flex items-center gap-1.5 text-xs text-threat"
           >
             <XCircle className="h-3.5 w-3.5 shrink-0" />
             {error}
           </p>
         ) : (
-          <p id="join-code-hint" className="text-xs text-[#D0D7E8]/50">
+          <p id="join-code-hint" className="text-xs text-mist/50">
             Ask your neighbourhood admin for a join code.
           </p>
         )}
@@ -164,7 +164,7 @@ function JoinForm({
       <Button
         type="submit"
         disabled={!code.trim() || loading}
-        className="w-full bg-[#3B5EDE] hover:bg-[#5B8DEF] text-white font-semibold transition-colors duration-100 focus-visible:ring-2 focus-visible:ring-[#3B5EDE] focus-visible:ring-offset-2 focus-visible:ring-offset-[#2C3E6B]"
+        className="w-full bg-blue hover:bg-sky text-white font-semibold transition-colors duration-100 focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-offset-2 focus-visible:ring-offset-steel"
       >
         {loading ? (
           <>
@@ -203,17 +203,17 @@ export default function JoinNeighbourhoodPage() {
 
   return (
     <div
-      className="w-full min-h-full flex flex-col items-center justify-center px-8 py-12 bg-[#1D2A5E]"
+      className="w-full min-h-full flex flex-col items-center justify-center px-8 py-12 bg-navy"
       style={{ fontFamily: "var(--font-sans, 'Inter', system-ui, sans-serif)" }}
     >
       <div className="w-full max-w-md">
         <div className="mb-6 text-center">
-          <h1 className="text-[32px] font-bold text-white leading-10">
+          <h1 className="text-[2rem] font-bold text-white leading-10">
             Join Neighbourhood
           </h1>
         </div>
 
-        <Card className="bg-[#2C3E6B] border-[#2C3E6B] p-6 rounded-2xl shadow-lg">
+        <Card className="bg-steel border-steel p-6 rounded-xl shadow-lg">
           {state.kind === "pending" ? (
             <PendingState request={state.request} />
           ) : (
@@ -226,7 +226,7 @@ export default function JoinNeighbourhoodPage() {
         </Card>
 
         {state.kind !== "pending" && (
-          <p className="text-center text-xs text-[#D0D7E8]/40 mt-5">
+          <p className="text-center text-xs text-mist/40 mt-5">
             Don&apos;t have a code? Contact your neighbourhood administrator.
           </p>
         )}

--- a/frontend/src/app/property/page.tsx
+++ b/frontend/src/app/property/page.tsx
@@ -73,10 +73,10 @@ function PropertyPageContent(){
         )}
         {!propertyData.neighbourhood && (
           <>
-            <p className="text-sm text-gray-500 mb-4">No neighbourhood assigned</p>
+            <p className="text-sm text-body mb-4">No neighbourhood assigned</p>
             <button
               onClick={() => setNeighbourhoodDialogOpen(true)}
-              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              className="px-4 py-2 bg-blue text-white rounded hover:bg-sky"
             >
               Create Neighbourhood
             </button>

--- a/frontend/src/app/request-page/page.tsx
+++ b/frontend/src/app/request-page/page.tsx
@@ -40,7 +40,7 @@ function EmptyState({ filter }: { filter: FilterValue }) {
       role="status"
       aria-live="polite"
     >
-      <p className="text-[15px] font-semibold text-white/50">
+      <p className="text-base font-semibold text-mist/50">
         No {filter === "ALL" ? "" : STATUS_LABELS[filter].toLowerCase()}{" "}
         requests
       </p>
@@ -58,7 +58,7 @@ function ErrorBanner({
   return (
     <div
       role="alert"
-      className="flex items-center gap-2 rounded-lg border border-[#DC2626]/30 bg-[#DC2626]/10 px-4 py-3 text-sm text-[#DC2626] mb-4"
+      className="flex items-center gap-2 rounded-lg border border-threat/30 bg-threat/10 px-4 py-3 text-sm text-threat mb-4"
     >
       <AlertCircle className="h-4 w-4 shrink-0" />
       <span className="flex-1">{message}</span>
@@ -66,7 +66,7 @@ function ErrorBanner({
         type="button"
         onClick={onDismiss}
         aria-label="Dismiss error"
-        className="ml-2 text-[#DC2626]/60 hover:text-[#DC2626] transition-colors"
+        className="ml-2 text-threat/60 hover:text-threat transition-colors"
       >
         ✕
       </button>
@@ -211,10 +211,10 @@ export default function JoinRequestsPage() {
   const pendingCount = requests.filter((r) => r.status === "PENDING").length;
 
   return (
-    <div className="w-full flex flex-col items-center px-8 py-10 bg-[#1D2A5E] min-h-full font-sans">
+    <div className="w-full flex flex-col items-center px-8 py-10 bg-navy min-h-full font-sans">
       <div className="w-full max-w-2xl">
         <header className="mb-6 text-center">
-          <h1 className="text-[32px] font-bold leading-10 text-white">
+          <h1 className="text-[2rem] font-bold leading-10 text-white">
             Join Requests
           </h1>
 
@@ -223,7 +223,7 @@ export default function JoinRequestsPage() {
               className="flex gap-2 mt-3 flex-wrap justify-center"
               aria-live="polite"
             >
-              <span className="inline-flex items-center gap-1 text-xs font-semibold bg-[#3B5EDE]/20 border border-[#3B5EDE]/30 rounded-full px-3 py-1 text-[#5B8DEF]">
+              <span className="inline-flex items-center gap-1 text-xs font-semibold bg-blue/20 border border-blue/30 rounded-full px-3 py-1 text-sky">
                 {pendingCount} pending
               </span>
             </div>
@@ -244,11 +244,11 @@ export default function JoinRequestsPage() {
           />
         )}
 
-        <Card className="bg-[#2C3E6B]/40 border-[#2C3E6B] rounded-2xl">
+        <Card className="bg-steel/40 border-steel rounded-xl">
           {/* Toolbar */}
-          <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-[#2C3E6B] rounded-t-2xl">
+          <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-steel rounded-t-xl">
             {/* Filter tabs */}
-            <div className="flex items-center bg-[#1D2A5E]/70 border border-[#2C3E6B] rounded-lg overflow-hidden">
+            <div className="flex items-center bg-navy/70 border border-steel rounded-lg overflow-hidden">
               {(
                 ["PENDING", ...ALL_STATUSES.slice(1), "ALL"] as FilterValue[]
               ).map((f, i, arr) => (
@@ -257,11 +257,11 @@ export default function JoinRequestsPage() {
                   type="button"
                   onClick={() => setActiveFilter(f)}
                   className={[
-                    "text-[11px] font-medium px-3 py-1.5 transition-colors duration-100",
-                    i < arr.length - 1 ? "border-r border-[#2C3E6B]" : "",
+                    "text-xs font-medium px-3 py-1.5 transition-colors duration-100",
+                    i < arr.length - 1 ? "border-r border-steel" : "",
                     activeFilter === f
-                      ? "bg-[#3B5EDE]/25 text-[#5B8DEF]"
-                      : "text-[#D0D7E8] hover:bg-[#2C3E6B] hover:text-white",
+                      ? "bg-blue/25 text-sky"
+                      : "text-mist hover:bg-steel hover:text-white",
                   ]
                     .filter(Boolean)
                     .join(" ")}
@@ -276,7 +276,7 @@ export default function JoinRequestsPage() {
               size="sm"
               onClick={() => setFetchTick((t) => t + 1)}
               disabled={loading}
-              className="text-[#5B8DEF] hover:text-white hover:bg-[#2C3E6B] transition-colors text-xs"
+              className="text-sky hover:text-white hover:bg-steel transition-colors text-xs"
               aria-label="Refresh requests"
             >
               {loading ? (
@@ -292,11 +292,11 @@ export default function JoinRequestsPage() {
           <section
             aria-label="Join request list"
             aria-live="polite"
-            className="p-4 rounded-b-2xl"
+            className="p-4 rounded-b-xl"
           >
             {loading ? (
               <div className="flex items-center justify-center py-16">
-                <Loader2 className="h-6 w-6 animate-spin text-[#5B8DEF]" />
+                <Loader2 className="h-6 w-6 animate-spin text-sky" />
               </div>
             ) : filtered.length === 0 ? (
               <EmptyState filter={activeFilter} />

--- a/frontend/src/app/test/page.tsx
+++ b/frontend/src/app/test/page.tsx
@@ -21,8 +21,8 @@ export default function Test() {
       <h1 className="text-2xl font-bold mb-4">Create Neighbourhood Dialog Test</h1>
       <Button onClick={() => setOpen(true)}>Open Create Neighbourhood Dialog</Button>
       {error && (
-        <div className="mt-4 p-4 border border-red-300 bg-red-50 rounded-lg">
-          <p className="text-red-700">{error}</p>
+        <div className="mt-4 p-4 border border-threat/30 bg-threat/10 rounded-lg">
+          <p className="text-threat">{error}</p>
         </div>
       )}
       <CreateNeighbourhoodDialog
@@ -32,7 +32,7 @@ export default function Test() {
       />
 
       {createdNeighbourhood && (
-        <div className="mt-8 p-4 border border-green-300 bg-green-50 rounded-lg">
+        <div className="mt-8 p-4 border border-safe/30 bg-safe/10 rounded-lg">
           <h2 className="text-lg font-bold mb-4">Created Neighbourhood</h2>
           <pre className="bg-white p-4 rounded border overflow-auto text-sm">
             {JSON.stringify(createdNeighbourhood, null, 2)}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -10,7 +10,7 @@ import { useAppView } from "@/components/app-view-context"
 function Placeholder({ title, description }: { title: string; description: string }) {
   return (
     <div className="watchdog-page-shell watchdog-page-shell--center">
-      <Card className="w-full max-w-2xl p-8 rounded-2xl watchdog-surface-strong text-white">
+      <Card className="w-full max-w-2xl p-8 rounded-xl watchdog-surface-strong text-white">
         <h1 className="watchdog-heading text-white">{title}</h1>
         <p className="mt-3 watchdog-text-subtle">{description}</p>
       </Card>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -122,7 +122,7 @@ function PinToggle({
             "flex items-center justify-center rounded-md p-1.5",
             "transition-colors duration-150",
             pinned
-              ? "text-[#5B8DEF] hover:text-white hover:bg-white/10"
+              ? "text-sky hover:text-white hover:bg-white/10"
               : "text-white/30 hover:text-white/70 hover:bg-white/10",
           )}
           aria-label={pinned ? "Unpin sidebar" : "Pin sidebar open"}
@@ -171,7 +171,7 @@ function NavTile({
         "flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm font-medium",
         "transition-all duration-150",
         isActive
-          ? "bg-[#1D2A5E] text-white shadow-[inset_0_0_0_1px_rgba(91,141,239,0.35)]"
+          ? "bg-navy text-white ring-inset ring-1 ring-sky/35"
           : "text-white/70 hover:bg-white/8 hover:text-white",
         !isExpanded && "justify-center px-2",
       )}
@@ -179,7 +179,7 @@ function NavTile({
       <span
         className={cn(
           "shrink-0",
-          isActive ? "text-[#5B8DEF]" : "text-white/60",
+          isActive ? "text-sky" : "text-white/60",
         )}
       >
         {item.icon}
@@ -222,7 +222,7 @@ function NavTile({
                   "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-xs font-medium",
                   "transition-colors duration-100",
                   activeChild === child.id
-                    ? "bg-[#1D2A5E] text-white shadow-[inset_0_0_0_1px_rgba(91,141,239,0.25)]"
+                    ? "bg-navy text-white ring-inset ring-1 ring-sky/25"
                     : "text-white/55 hover:bg-white/8 hover:text-white/90",
                 )}
               >
@@ -230,7 +230,7 @@ function NavTile({
                   className={cn(
                     "shrink-0",
                     activeChild === child.id
-                      ? "text-[#5B8DEF]"
+                      ? "text-sky"
                       : "text-white/40",
                   )}
                 >
@@ -238,7 +238,7 @@ function NavTile({
                 </span>
                 <span className="truncate">{child.label}</span>
                 {activeChild === child.id && (
-                  <ChevronRight className="ml-auto h-3 w-3 text-[#5B8DEF]" />
+                  <ChevronRight className="ml-auto h-3 w-3 text-sky" />
                 )}
               </button>
             </li>
@@ -370,7 +370,7 @@ export function AppSidebar() {
                     <p className="text-sm font-extrabold text-white leading-tight tracking-tight truncate">
                       Neighbourhood
                     </p>
-                    <p className="text-xs font-semibold text-[#5B8DEF] leading-tight tracking-widest uppercase truncate">
+                    <p className="text-xs font-semibold text-sky leading-tight tracking-widest uppercase truncate">
                       WatchDog
                     </p>
                   </div>
@@ -431,8 +431,8 @@ export function AppSidebar() {
                     !isExpanded && "justify-center",
                   )}
                 >
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#3B5EDE]/40 ring-1 ring-[#5B8DEF]/40">
-                    <User className="h-3.5 w-3.5 text-[#5B8DEF]" />
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue/40 ring-1 ring-sky/40">
+                    <User className="h-3.5 w-3.5 text-sky" />
                   </span>
                   {isExpanded && (
                     <span className="truncate text-sm font-medium text-white/80">

--- a/frontend/src/components/auth-components/forgetpassword-card.tsx
+++ b/frontend/src/components/auth-components/forgetpassword-card.tsx
@@ -19,22 +19,22 @@ type ForgotPasswordCardProps = {
 export function ForgotPasswordCard({ className }: ForgotPasswordCardProps) {
   return (
     <Card className={cn(
-      "w-full max-w-md sm:max-w-xl rounded-3xl border border-[rgba(29,42,94,0.12)] bg-white/95 shadow-[0_20px_60px_rgba(29,42,94,0.14)] backdrop-blur",
+      "w-full max-w-md sm:max-w-xl rounded-xl border border-navy/12 bg-white/95 shadow-lg backdrop-blur",
       className
     )}>
       <CardHeader>
-        <CardTitle className="text-3xl sm:text-4xl font-semibold tracking-tight text-[color:var(--color-navy)]">
+        <CardTitle className="text-[2rem] sm:text-[2rem] font-semibold tracking-tight text-navy">
           Forgot your password?
         </CardTitle>
 
-        <CardDescription className="text-base text-[color:var(--color-body)]">
+        <CardDescription className="text-base text-body">
           Enter your email below and we will send a message to reset your password
         </CardDescription>
 
         <CardAction>
           <Button
             variant="link"
-            className="text-[color:var(--color-sky)] hover:text-[color:var(--color-blue)]"
+            className="text-sky hover:text-blue"
           >
             Login
           </Button>
@@ -45,7 +45,7 @@ export function ForgotPasswordCard({ className }: ForgotPasswordCardProps) {
         <form>
           <div className="flex flex-col gap-6">
             <div className="grid gap-2">
-              <Label htmlFor="email" className="font-medium text-[color:var(--color-body)]">
+              <Label htmlFor="email" className="font-medium text-body">
                 Email
               </Label>
               <Input
@@ -62,7 +62,7 @@ export function ForgotPasswordCard({ className }: ForgotPasswordCardProps) {
       <CardFooter className="flex-col gap-2">
         <Button
           type="submit"
-          className="w-full bg-[color:var(--color-navy)] text-white hover:bg-[color:var(--color-steel)]"
+          className="w-full bg-navy text-white hover:bg-steel"
         >
           Send reset link
         </Button>

--- a/frontend/src/components/auth-components/login-card.tsx
+++ b/frontend/src/components/auth-components/login-card.tsx
@@ -35,16 +35,16 @@ export function LoginCard({
   return (
     <Card
       className={cn(
-        "w-full max-w-md sm:max-w-xl rounded-3xl border border-[rgba(29,42,94,0.12)] bg-white/95 shadow-[0_20px_60px_rgba(29,42,94,0.14)] backdrop-blur",
+        "w-full max-w-md sm:max-w-xl rounded-xl border border-navy/12 bg-white/95 shadow-lg backdrop-blur",
         className
       )}
     >
       <CardHeader>
-        <CardTitle className="text-3xl sm:text-4xl font-semibold tracking-tight text-[color:var(--color-navy)]">
+        <CardTitle className="text-[2rem] sm:text-[2rem] font-semibold tracking-tight text-navy">
           Login to your account
         </CardTitle>
 
-        <CardDescription className="text-base text-[color:var(--color-body)]">
+        <CardDescription className="text-base text-body">
           Enter your email below to login to your account
         </CardDescription>
 
@@ -88,7 +88,7 @@ export function LoginCard({
         <Button
           type="button"
           onClick={onSubmit}
-          className="w-full bg-[color:var(--color-navy)] text-white hover:bg-[color:var(--color-steel)]"
+          className="w-full bg-navy text-white hover:bg-steel"
         >
           Login
         </Button>

--- a/frontend/src/components/auth-components/signup-card.tsx
+++ b/frontend/src/components/auth-components/signup-card.tsx
@@ -50,16 +50,16 @@ export function SignupCard({
   return (
     <Card
       className={cn(
-        "w-full max-w-md sm:max-w-xl rounded-3xl border border-[rgba(29,42,94,0.12)] bg-white/95 shadow-[0_20px_60px_rgba(29,42,94,0.14)] backdrop-blur",
+        "w-full max-w-md sm:max-w-xl rounded-xl border border-navy/12 bg-white/95 shadow-lg backdrop-blur",
         className
       )}
     >
       <CardHeader>
-        <CardTitle className="text-3xl sm:text-4xl font-semibold tracking-tight text-[color:var(--color-navy)]">
+        <CardTitle className="text-[2rem] sm:text-[2rem] font-semibold tracking-tight text-navy">
           Create your account
         </CardTitle>
 
-        <CardDescription className="text-base text-[color:var(--color-body)]">
+        <CardDescription className="text-base text-body">
           Enter your details below to sign up
         </CardDescription>
 
@@ -139,7 +139,7 @@ export function SignupCard({
         <Button
           type="button"
           onClick={onSubmit}
-          className="w-full bg-[color:var(--color-navy)] text-white hover:bg-[color:var(--color-steel)]"
+          className="w-full bg-navy text-white hover:bg-steel"
         >
           Sign Up
         </Button>

--- a/frontend/src/components/create-neighbourhood-dialog.tsx
+++ b/frontend/src/components/create-neighbourhood-dialog.tsx
@@ -74,7 +74,7 @@ export function CreateNeighbourhoodDialog(
   // TODO: refactor this dialogue to use the same component as the createpropertyone and just to pass in the fields that the user must enter
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-sm [font-family:var(--font-jetbrains-mono)]">
+      <DialogContent className="sm:max-w-sm font-mono">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold">
             {loading && <Spinner className="mr-2 h-4 w-4 animate-spin" />}
@@ -86,14 +86,14 @@ export function CreateNeighbourhoodDialog(
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           {errors.submit && (
-            <p className="text-sm text-red-500 mb-4">{errors.submit}</p>
+            <p className="text-sm text-threat mb-4">{errors.submit}</p>
           )}
           <FieldGroup>
             <Field>
               <Label htmlFor="name-1">Neighbourhood Name</Label>
               <Input id="name-1" name="name" defaultValue="" placeholder="e.g., Westwood Heights" />
               {errors["name"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["name"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["name"]}</p>
               )}
             </Field>
 
@@ -101,7 +101,7 @@ export function CreateNeighbourhoodDialog(
               <Label htmlFor="location-1">Location</Label>
               <Input id="location-1" name="location" defaultValue="" placeholder="e.g., Johannesburg, Gauteng" />
               {errors["location"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["location"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["location"]}</p>
               )}
             </Field>
           </FieldGroup>

--- a/frontend/src/components/create-property-dialogue.tsx
+++ b/frontend/src/components/create-property-dialogue.tsx
@@ -104,7 +104,7 @@ export function CreatePropertyDialog({ open, onOpenChange, onPropertyAdded }: Cr
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-sm [font-family:var(--font-jetbrains-mono)]">
+      <DialogContent className="sm:max-w-sm font-mono">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold">
             {loading && <Spinner className="mr-2 h-4 w-4 animate-spin" />}
@@ -116,14 +116,14 @@ export function CreatePropertyDialog({ open, onOpenChange, onPropertyAdded }: Cr
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           {errors.submit && (
-            <p className="text-sm text-red-500 mb-4">{errors.submit}</p>
+            <p className="text-sm text-threat mb-4">{errors.submit}</p>
           )}
           <FieldGroup>
             <Field>
               <Label htmlFor="add-line-1">Address Line 1 (Street address)</Label>
               <Input id="add-line-1" name="address-line-1" defaultValue="" />
               {errors["address-line-1"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["address-line-1"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["address-line-1"]}</p>
               )}
             </Field>
 
@@ -131,7 +131,7 @@ export function CreatePropertyDialog({ open, onOpenChange, onPropertyAdded }: Cr
               <Label htmlFor="add-line-2">Address Line 2 (Apartment, suite, unit, building etc.)</Label>
               <Input id="add-line-2" name="address-line-2" defaultValue="" />
               {errors["address-line-2"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["address-line-2"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["address-line-2"]}</p>
               )}
             </Field>
 
@@ -139,7 +139,7 @@ export function CreatePropertyDialog({ open, onOpenChange, onPropertyAdded }: Cr
               <Label htmlFor="city-1">City</Label>
               <Input id="city-1" name="city" defaultValue="" />
               {errors["city"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["city"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["city"]}</p>
               )}
             </Field>
 
@@ -163,7 +163,7 @@ export function CreatePropertyDialog({ open, onOpenChange, onPropertyAdded }: Cr
                 <option value="Western Cape">Western Cape</option>
               </select>
               {errors["province"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["province"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["province"]}</p>
               )}
             </Field>
 
@@ -171,7 +171,7 @@ export function CreatePropertyDialog({ open, onOpenChange, onPropertyAdded }: Cr
               <Label htmlFor="postal-code-1">Postal Code</Label>
               <Input id="postal-code-1" name="postal-code" defaultValue="" />
               {errors["postal-code"] && (
-                <p className="text-sm text-red-500 text-xs mt-0.5">{errors["postal-code"]}</p>
+                <p className="text-sm text-threat text-xs mt-0.5">{errors["postal-code"]}</p>
               )}
             </Field>
             

--- a/frontend/src/components/info-card.tsx
+++ b/frontend/src/components/info-card.tsx
@@ -9,7 +9,7 @@ interface InfoCardProps {
 
 export function InfoCard({ title, children }: InfoCardProps) {
   return (
-    <Card className="!bg-navy text-black rounded-lg p-6">
+    <Card className="!bg-navy text-white rounded-lg p-6">
       <h2 className="text-xl font-bold mb-4">{title}</h2>
       <div className="text-sm">{children}</div>
     </Card>

--- a/frontend/src/components/list-card.tsx
+++ b/frontend/src/components/list-card.tsx
@@ -12,22 +12,22 @@ interface ListCardProps {
 
 export function ListCard({ title, items, onAdd, onDelete }: ListCardProps){
   return (
-    <Card className="!bg-navy text-black rounded-lg p-5">
+    <Card className="!bg-navy text-white rounded-lg p-5">
       <h2 className="text-xl font-bold">{title}</h2>
 
       {/** creating the list of whatever it may be */}
       <div className="space-y-2">
         { items.map((item) => (
-          <div key={item.id} className="flex justify-between items-center border-1 p-2 rounded-full">
+          <div key={item.id} className="flex justify-between items-center border p-2 rounded-full">
             <span>{item.name}</span>
             <button onClick={() => onDelete(item.id)}>
-              <Trash2 className="h-4 w-4 text-black"/>
+              <Trash2 className="h-4 w-4 text-white"/>
             </button>
           </div>
         ))}
       </div>
 
-      <button onClick={onAdd} className="bg-blue-500 text-navy rounded-full p-2 ">
+      <button onClick={onAdd} className="bg-blue text-navy rounded-full p-2 ">
         {/* <Plus className="h-4 w-4"/> */}
         <p>Add</p>
       </button>

--- a/frontend/src/components/new-camera-card.tsx
+++ b/frontend/src/components/new-camera-card.tsx
@@ -32,11 +32,11 @@ export function NewCameraCard({ onClose, onAcknowledge }: NewCameraCardProps) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <Card className="w-full max-w-md bg-white rounded-2xl shadow-xl">
+      <Card className="w-full max-w-md bg-white rounded-xl shadow-xl">
         <CardHeader className="relative flex items-center justify-center pb-2">
           <button
             onClick={onClose}
-            className="absolute left-4 top-4 text-gray-500 hover:text-gray-800 transition-colors"
+            className="absolute left-4 top-4 text-body hover:text-ink transition-colors"
           >
             <X size={20} />
           </button>
@@ -56,10 +56,10 @@ export function NewCameraCard({ onClose, onAcknowledge }: NewCameraCardProps) {
               value={cameraLocation}
               onChange={(e) => setCameraLocation(e.target.value)}
               onBlur={() => setTouched((t) => ({ ...t, cameraLocation: true }))}
-              className={`bg-gray-50 border-gray-200 ${errors.cameraLocation ? "border-red-500 focus-visible:ring-red-400" : ""}`}
+              className={`bg-mist/10 border-mist/40 ${errors.cameraLocation ? "border-threat focus-visible:ring-threat" : ""}`}
             />
             {errors.cameraLocation && (
-              <p className="text-xs text-red-500">Camera location is required.</p>
+              <p className="text-xs text-threat">Camera location is required.</p>
             )}
           </div>
 
@@ -73,17 +73,17 @@ export function NewCameraCard({ onClose, onAcknowledge }: NewCameraCardProps) {
               value={rtspUrl}
               onChange={(e) => setRtspUrl(e.target.value)}
               onBlur={() => setTouched((t) => ({ ...t, rtspUrl: true }))}
-              className={`bg-gray-50 border-gray-200 ${errors.rtspUrl ? "border-red-500 focus-visible:ring-red-400" : ""}`}
+              className={`bg-mist/10 border-mist/40 ${errors.rtspUrl ? "border-threat focus-visible:ring-threat" : ""}`}
             />
             {errors.rtspUrl && (
-              <p className="text-xs text-red-500">RTSP URL is required.</p>
+              <p className="text-xs text-threat">RTSP URL is required.</p>
             )}
           </div>
 
           <Button
             onClick={handleSubmit}
             disabled={!isValid}
-            className="w-full bg-blue-500 hover:bg-blue-600 text-white rounded-full font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full bg-blue hover:bg-sky text-white rounded-full font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Acknowledge
           </Button>

--- a/frontend/src/components/shared/AlertCard.tsx
+++ b/frontend/src/components/shared/AlertCard.tsx
@@ -66,22 +66,22 @@ const SEVERITY_CONFIG: Record<
   { bg: string; label: string; icon: ReactNode }
 > = {
   CRITICAL: {
-    bg: "bg-[#DC2626] text-white",
+    bg: "bg-threat text-white",
     label: "Critical",
     icon: <ShieldAlert className="h-3 w-3" />,
   },
   HIGH: {
-    bg: "bg-[#D97706] text-white",
+    bg: "bg-caution text-white",
     label: "High",
     icon: <AlertTriangle className="h-3 w-3" />,
   },
   MEDIUM: {
-    bg: "bg-[#0284C7] text-white",
+    bg: "bg-info text-white",
     label: "Medium",
     icon: <Info className="h-3 w-3" />,
   },
   LOW: {
-    bg: "bg-[#16A34A] text-white",
+    bg: "bg-safe text-white",
     label: "Low",
     icon: <CheckCircle2 className="h-3 w-3" />,
   },
@@ -92,20 +92,20 @@ const STATUS_CONFIG: Record<
   { bg: string; textColor: string; label: string; icon: ReactNode }
 > = {
   NEW: {
-    bg: "bg-[#3B5EDE]/20 border border-[#3B5EDE]/40",
-    textColor: "text-[#5B8DEF]",
+    bg: "bg-blue/20 border border-blue/40",
+    textColor: "text-sky",
     label: "New",
     icon: <Activity className="h-3 w-3" />,
   },
   ACKNOWLEDGED: {
-    bg: "bg-[#D0D7E8]/20 border border-[#D0D7E8]/40",
-    textColor: "text-[#D0D7E8]",
+    bg: "bg-mist/20 border border-mist/40",
+    textColor: "text-mist",
     label: "Acknowledged",
     icon: <CheckCheck className="h-3 w-3" />,
   },
   RESOLVED: {
-    bg: "bg-[#16A34A]/20 border border-[#16A34A]/40",
-    textColor: "text-[#16A34A]",
+    bg: "bg-safe/20 border border-safe/40",
+    textColor: "text-safe",
     label: "Resolved",
     icon: <CheckCircle2 className="h-3 w-3" />,
   },
@@ -115,7 +115,7 @@ export function SeverityBadge({ severity }: { severity: AlertSeverity }) {
   const config = SEVERITY_CONFIG[severity];
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${config.bg}`}
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${config.bg}`}
       aria-label={`Severity: ${config.label}`}
     >
       {config.icon}
@@ -128,7 +128,7 @@ export function StatusBadge({ status }: { status: AlertStatus }) {
   const config = STATUS_CONFIG[status];
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${config.bg} ${config.textColor}`}
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${config.bg} ${config.textColor}`}
       aria-label={`Status: ${config.label}`}
     >
       {config.icon}
@@ -192,7 +192,7 @@ function AlertDetailSheet({
     <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
       <SheetContent
         side="right"
-        className="w-full max-w-md border-l border-[#2C3E6B] bg-[#1D2A5E] text-white"
+        className="w-full max-w-md border-l border-steel bg-navy text-white"
         style={{ boxShadow: "var(--shadow-lg)" }}
       >
         <SheetHeader className="mb-6">
@@ -200,17 +200,17 @@ function AlertDetailSheet({
             <SeverityBadge severity={severity} />
             <StatusBadge status={alert.status} />
           </div>
-          <SheetTitle className="text-white text-[20px] font-semibold leading-7">
+          <SheetTitle className="text-white text-xl font-semibold leading-7">
             {detectionLabel(alert.detection_type)}
           </SheetTitle>
-          <SheetDescription className="text-[#D0D7E8] text-sm">
+          <SheetDescription className="text-mist text-sm">
             Full alert details
           </SheetDescription>
         </SheetHeader>
 
         <div className="space-y-4">
           {alert.thumbnail_url ? (
-            <div className="relative rounded-lg overflow-hidden border border-[#2C3E6B]">
+            <div className="relative rounded-lg overflow-hidden border border-steel">
               <Image
                 src={alert.thumbnail_url}
                 alt="Detection thumbnail"
@@ -221,13 +221,13 @@ function AlertDetailSheet({
               />
             </div>
           ) : (
-            <div className="rounded-lg border border-[#2C3E6B] bg-[#2C3E6B]/40 h-40 flex items-center justify-center gap-2">
-              <Camera className="h-8 w-8 text-[#5B8DEF] opacity-50" />
-              <span className="text-sm text-[#D0D7E8]/60">No thumbnail</span>
+            <div className="rounded-lg border border-steel bg-steel/40 h-40 flex items-center justify-center gap-2">
+              <Camera className="h-8 w-8 text-sky opacity-50" />
+              <span className="text-sm text-mist/60">No thumbnail</span>
             </div>
           )}
 
-          <Separator className="bg-[#2C3E6B]" />
+          <Separator className="bg-steel" />
 
           <div className="space-y-3">
             <MetaRow label="Alert ID" value={alert.id} mono />
@@ -261,11 +261,11 @@ function AlertDetailSheet({
             )}
           </div>
 
-          <Separator className="bg-[#2C3E6B]" />
+          <Separator className="bg-steel" />
 
           {isNew && (
             <Button
-              className="w-full bg-[#3B5EDE] hover:bg-[#5B8DEF] text-white font-medium transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-[#3B5EDE] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1D2A5E]"
+              className="w-full bg-blue hover:bg-sky text-white font-medium transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-offset-2 focus-visible:ring-offset-navy"
               onClick={() => onAcknowledge(alert.id)}
               disabled={acknowledging}
               aria-label="Acknowledge this alert"
@@ -300,7 +300,7 @@ function MetaRow({
 }) {
   return (
     <div className="flex justify-between gap-4">
-      <span className="text-xs font-medium text-[#D0D7E8]/70 shrink-0">
+      <span className="text-xs font-medium text-mist/70 shrink-0">
         {label}
       </span>
       <span
@@ -340,12 +340,12 @@ export function AlertCard({ alert, onAcknowledge }: AlertCardProps) {
       <Card
         className={[
           "relative flex flex-col sm:flex-row sm:items-center gap-4 p-4 rounded-xl border transition-all duration-200",
-          "bg-[#2C3E6B] border-[#2C3E6B]",
+          "bg-steel border-steel",
           isNew
-            ? "hover:border-[#3B5EDE]/60 hover:shadow-md"
+            ? "hover:border-blue/60 hover:shadow-md"
             : "opacity-80 hover:opacity-100",
           isCritical && isNew
-            ? "border-[#DC2626]/40 shadow-[0_0_0_1px_rgba(220,38,38,0.20)]"
+            ? "border-threat/40 shadow-alert"
             : "",
         ]
           .filter(Boolean)
@@ -359,20 +359,20 @@ export function AlertCard({ alert, onAcknowledge }: AlertCardProps) {
             <SeverityBadge severity={severity} />
             <StatusBadge status={alert.status} />
           </div>
-          <p className="text-[15px] font-semibold text-white leading-snug truncate">
+          <p className="text-base font-semibold text-white leading-snug truncate">
             {detectionLabel(alert.detection_type)}
           </p>
           <div className="flex flex-wrap items-center gap-3 mt-1">
-            <span className="flex items-center gap-1 text-[11px] text-[#D0D7E8]/70 font-mono">
+            <span className="flex items-center gap-1 text-xs text-mist/70 font-mono">
               <Camera className="h-3 w-3" />
               {alert.camera_id.slice(0, 8)}…
             </span>
             {alert.confidence_score != null && (
-              <span className="text-[11px] text-[#D0D7E8]/70 font-mono">
+              <span className="text-xs text-mist/70 font-mono">
                 {(alert.confidence_score * 100).toFixed(0)}% confidence
               </span>
             )}
-            <span className="flex items-center gap-1 text-[11px] text-[#D0D7E8]/60 font-mono">
+            <span className="flex items-center gap-1 text-xs text-mist/60 font-mono">
               <Clock className="h-3 w-3" />
               {timeAgo(alert.created_at)}
             </span>
@@ -386,7 +386,7 @@ export function AlertCard({ alert, onAcknowledge }: AlertCardProps) {
               <Button
                 variant="ghost"
                 size="sm"
-                className="text-[#5B8DEF] hover:text-white hover:bg-[#3B5EDE]/20 text-xs font-medium transition-colors duration-100"
+                className="text-sky hover:text-white hover:bg-blue/20 text-xs font-medium transition-colors duration-100"
                 onClick={() => setDetailOpen(true)}
                 aria-label="View alert details"
               >
@@ -402,7 +402,7 @@ export function AlertCard({ alert, onAcknowledge }: AlertCardProps) {
               <TooltipTrigger asChild>
                 <Button
                   size="sm"
-                  className="bg-[#3B5EDE] hover:bg-[#5B8DEF] text-white text-xs font-semibold transition-colors duration-100 focus-visible:ring-2 focus-visible:ring-[#3B5EDE] focus-visible:ring-offset-2 focus-visible:ring-offset-[#2C3E6B]"
+                  className="bg-blue hover:bg-sky text-white text-xs font-semibold transition-colors duration-100 focus-visible:ring-2 focus-visible:ring-blue focus-visible:ring-offset-2 focus-visible:ring-offset-steel"
                   onClick={() => handleAcknowledge(alert.id)}
                   disabled={acknowledging}
                   aria-label="Acknowledge alert"

--- a/frontend/src/components/shared/RequestCard.tsx
+++ b/frontend/src/components/shared/RequestCard.tsx
@@ -44,17 +44,17 @@ const STATUS_CONFIG: Record<
   { badge: string; label: string; icon: ReactNode }
 > = {
   PENDING: {
-    badge: "bg-[#3B5EDE]/20 border border-[#3B5EDE]/40 text-[#5B8DEF]",
+    badge: "bg-blue/20 border border-blue/40 text-sky",
     label: "Pending",
     icon: <Clock className="h-2.5 w-2.5" />,
   },
   APPROVED: {
-    badge: "bg-[#16A34A]/15 border border-[#16A34A]/30 text-[#16A34A]",
+    badge: "bg-safe/15 border border-safe/30 text-safe",
     label: "Approved",
     icon: <CheckCheck className="h-2.5 w-2.5" />,
   },
   DENIED: {
-    badge: "bg-[#DC2626]/12 border border-[#DC2626]/25 text-[#DC2626]",
+    badge: "bg-threat/12 border border-threat/25 text-threat",
     label: "Denied",
     icon: <XCircle className="h-2.5 w-2.5" />,
   },
@@ -65,19 +65,19 @@ const AVATAR_CONFIG: Record<
   { bg: string; border: string; text: string }
 > = {
   PENDING: {
-    bg: "bg-[#3B5EDE]/20",
-    border: "border-[#3B5EDE]/30",
-    text: "text-[#5B8DEF]",
+    bg: "bg-blue/20",
+    border: "border-blue/30",
+    text: "text-sky",
   },
   APPROVED: {
-    bg: "bg-[#16A34A]/15",
-    border: "border-[#16A34A]/25",
-    text: "text-[#16A34A]",
+    bg: "bg-safe/15",
+    border: "border-safe/25",
+    text: "text-safe",
   },
   DENIED: {
-    bg: "bg-[#DC2626]/12",
-    border: "border-[#DC2626]/20",
-    text: "text-[#DC2626]",
+    bg: "bg-threat/12",
+    border: "border-threat/20",
+    text: "text-threat",
   },
 };
 
@@ -119,8 +119,8 @@ export function RequestCard({ request, onApprove, onDeny }: RequestCardProps) {
     <Card
       className={[
         "flex flex-col items-center gap-3 px-4 py-4 rounded-xl border transition-all duration-150",
-        "bg-[#2C3E6B] border-[#2C3E6B]",
-        isPending ? "hover:border-[#3B5EDE]/50" : "opacity-70 hover:opacity-90",
+        "bg-steel border-steel",
+        isPending ? "hover:border-blue/50" : "opacity-70 hover:opacity-90",
       ]
         .filter(Boolean)
         .join(" ")}
@@ -131,7 +131,7 @@ export function RequestCard({ request, onApprove, onDeny }: RequestCardProps) {
       <div
         className={[
           "h-10 w-10 rounded-full border flex items-center justify-center shrink-0",
-          "text-[13px] font-semibold tracking-wide",
+          "text-sm font-semibold tracking-wide",
           avatarCfg.bg,
           avatarCfg.border,
           avatarCfg.text,
@@ -147,15 +147,15 @@ export function RequestCard({ request, onApprove, onDeny }: RequestCardProps) {
 
       {/* Info */}
       <div className="flex-1 min-w-0 text-center">
-        <p className="text-[14px] font-semibold text-white truncate leading-snug">
+        <p className="text-sm font-semibold text-white truncate leading-snug">
           {request.user_name}
         </p>
         <div className="flex flex-wrap items-center gap-3 mt-0.5">
-          <span className="flex items-center gap-1 text-[11px] text-[#D0D7E8]/60 font-mono">
+          <span className="flex items-center gap-1 text-xs text-mist/60 font-mono">
             <Clock className="h-2.5 w-2.5" />
             {timeAgo(request.created_at)}
           </span>
-          <span className="text-[11px] text-[#D0D7E8]/40 font-mono truncate hidden sm:inline">
+          <span className="text-xs text-mist/40 font-mono truncate hidden sm:inline">
             {request.id}
           </span>
         </div>
@@ -163,7 +163,7 @@ export function RequestCard({ request, onApprove, onDeny }: RequestCardProps) {
 
       {/* Status badge */}
       <span
-        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest shrink-0 ${statusCfg.badge}`}
+        className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold uppercase tracking-widest shrink-0 ${statusCfg.badge}`}
         aria-label={`Status: ${statusCfg.label}`}
       >
         {statusCfg.icon}
@@ -178,7 +178,7 @@ export function RequestCard({ request, onApprove, onDeny }: RequestCardProps) {
             disabled={isLoading}
             onClick={handleApprove}
             aria-label="Approve join request"
-            className="bg-[#16A34A]/15 hover:bg-[#16A34A]/30 text-[#16A34A] border border-[#16A34A]/30 text-[11px] font-semibold transition-colors duration-100 h-7 px-3"
+            className="bg-safe/15 hover:bg-safe/30 text-safe border border-safe/30 text-xs font-semibold transition-colors duration-100 h-7 px-3"
           >
             {approvingId ? (
               <Loader2 className="h-3 w-3 animate-spin" />
@@ -195,7 +195,7 @@ export function RequestCard({ request, onApprove, onDeny }: RequestCardProps) {
             disabled={isLoading}
             onClick={handleDeny}
             aria-label="Deny join request"
-            className="bg-[#DC2626]/10 hover:bg-[#DC2626]/20 text-[#DC2626] border border-[#DC2626]/25 text-[11px] font-semibold transition-colors duration-100 h-7 px-3"
+            className="bg-threat/10 hover:bg-threat/20 text-threat border border-threat/25 text-xs font-semibold transition-colors duration-100 h-7 px-3"
           >
             {denyingId ? (
               <Loader2 className="h-3 w-3 animate-spin" />


### PR DESCRIPTION
Replaced all raw hex colours, default Tailwind colours, and arbitrary pixel values across frontend components with the design system tokens defined in globals.css. Also fixed the radius scale and remapped shadcn CSS variables to match the spec.

Closes #144